### PR TITLE
chore: use node20

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16, 18]
+        node-version: [20]
 
     steps:
       - uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,5 @@ inputs:
     description: String containing a date in `YYYY-MM-DD hh:mm:ss` format after which the linting will start.
     required: false
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
Quick change to have the action and workflow use node20. I tested it against a repo where I use the original lekterable version.

Addresses issue
https://github.com/lekterable/branchlint-action/issues/7